### PR TITLE
Make copy instructions idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Publishing the Apache Pekko web site requires:
 
 1. Clone https://github.com/apache/incubator-pekko-site into a local directory.
 2. Check out the asf-staging branch.
-3. If you have used `sbt docs/paradox` in `incubator-pekko` repo, you can use `cp -r <path>/incubator-pekko/docs/target/paradox/site/main/ content/`
+3. If you have used `sbt docs/paradox` in `incubator-pekko` repo, you can use `rm -r content; cp -r <path>/incubator-pekko/docs/target/paradox/site/main/ content/`
 4. Perform `git add` on the affected files and `git commit`.
 5. Perform `git push`.
 6. After a few minutes review https://pekko.staged.apache.org and make sure the appropriate changes are present.


### PR DESCRIPTION
Running the `cp` command when the target is already present does not give the desired result. Adding `-T` wouldn't be right because it would prevent us from ever deleting files from the docs. We want a fresh version as generated, so best to remove then re-add.