### PR TITLE
Fixing search in homepage.

### DIFF
--- a/content/assets/stylesheets/home.css
+++ b/content/assets/stylesheets/home.css
@@ -20,10 +20,6 @@
   background-color: #eef0f2;
 }
 
-h1 {
-  display: none;
-}
-
 .md-container {
   cursor: default;
 }
@@ -34,12 +30,13 @@ h1 {
   color: white;
 }
 
-.title > h2 {
+.title > h1 {
   font-size: 4.5rem;
   text-align: left;
+  color: white;
 }
 
-.md-typeset .title h2,
+.md-typeset .title h1,
 .md-typeset ul li ul {
   margin: 0
 }
@@ -145,7 +142,7 @@ h1 {
     margin: 20px 0;
   }
 
-  .title h2 {
+  .title h1 {
     text-align: center;
   }
 

--- a/content/index.html
+++ b/content/index.html
@@ -199,7 +199,7 @@ apache/incubator-pekko
   <li><a href="how-to-contribute.html">How to contribute</a></li>
 </ul></div><div class="hero"><div class="banner-logo">
 <p>Banner Logo</p></div><div class="title">
-<h2><a href="#apache-pekko" name="apache-pekko" class="anchor"><span class="anchor-link"></span></a>Apache Pekko</h2>
+<h1><a href="#apache-pekko" name="apache-pekko" class="anchor"><span class="anchor-link"></span></a>Apache Pekko</h1>
 <p>Apache Pekko (Incubating) is an open-source framework for building applications that are concurrent, distributed, resilient and elastic. Pekko uses the Actor Model to provide more intuitive high-level abstractions for concurrency. Using these abstractions, Pekko also provides libraries for persistence, streams, HTTP, and more.</p>
 <p>Apache Pekko is a fork of <a href="https://github.com/akka/akka">Akka</a> 2.6.x, prior to the Akka project&rsquo;s adoption of the Business Source License.</p></div></div><div class="row"><div class="subtitle">
 <p>Getting Started</p></div>

--- a/src/main/paradox/_template/assets/stylesheets/home.css
+++ b/src/main/paradox/_template/assets/stylesheets/home.css
@@ -20,10 +20,6 @@
   background-color: #eef0f2;
 }
 
-h1 {
-  display: none;
-}
-
 .md-container {
   cursor: default;
 }
@@ -34,12 +30,13 @@ h1 {
   color: white;
 }
 
-.title > h2 {
+.title > h1 {
   font-size: 4.5rem;
   text-align: left;
+  color: white;
 }
 
-.md-typeset .title h2,
+.md-typeset .title h1,
 .md-typeset ul li ul {
   margin: 0
 }
@@ -145,7 +142,7 @@ h1 {
     margin: 20px 0;
   }
 
-  .title h2 {
+  .title h1 {
     text-align: center;
   }
 

--- a/src/main/paradox/index.md
+++ b/src/main/paradox/index.md
@@ -24,7 +24,7 @@ Banner Logo
 @@@@
 
 @@@@ div { .title }
-## Apache Pekko
+# Apache Pekko
 
 Apache Pekko (Incubating) is an open-source framework for building applications that are concurrent, distributed, resilient and elastic.
 Pekko uses the Actor Model to provide more intuitive high-level abstractions for concurrency.


### PR DESCRIPTION
Fixes #74.

The theme require an `h1` element in the page for listening the scroll events on Js side. Without an h1 the whole js was breaking therefore, the search wasn't working