### PR TITLE
support snapshot redirect

### DIFF
--- a/content/.htaccess
+++ b/content/.htaccess
@@ -55,6 +55,10 @@ RewriteRule ^japi/([^/]+)/1.0.2/(.*)$ https://nightlies.apache.org/pekko/docs/$1
 RewriteRule ^docs/([^/]+)/1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0/docs/$2 [P]
 RewriteRule ^api/([^/]+)/1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0/api/$2 [P]
 RewriteRule ^japi/([^/]+)/1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0/japi/$2 [P]
+# snapshots redirect
+RewriteRule ^docs/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/docs/$2 [P]
+RewriteRule ^api/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/api/$2 [P]
+RewriteRule ^japi/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/japi/$2 [P]
 
 # Security Headers
 Header set Strict-Transport-Security "max-age=31536000"

--- a/content/.htaccess
+++ b/content/.htaccess
@@ -35,7 +35,7 @@ RewriteRule ^api/pekko-persistence-r2dbc/current/(.*)$ https://nightlies.apache.
 # pekko-projection/current gets redirected to pekko-projection/1.0.0
 RewriteRule ^docs/pekko-projection/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-projection/1.0.0/docs/$1 [P]
 RewriteRule ^api/pekko-projection/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-projection/1.0.0/api/$1 [P]
-# pekko-*/current gets redirected to pekko-*/snapshot because no releases exist yet
+# pekko-*/current gets redirected to pekko-*/snapshot if no releases exist yet
 RewriteRule ^docs/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/docs/$2 [P]
 RewriteRule ^api/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/api/$2 [P]
 RewriteRule ^japi/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/japi/$2 [P]

--- a/src/main/public/.htaccess
+++ b/src/main/public/.htaccess
@@ -55,6 +55,10 @@ RewriteRule ^japi/([^/]+)/1.0.2/(.*)$ https://nightlies.apache.org/pekko/docs/$1
 RewriteRule ^docs/([^/]+)/1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0/docs/$2 [P]
 RewriteRule ^api/([^/]+)/1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0/api/$2 [P]
 RewriteRule ^japi/([^/]+)/1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0/japi/$2 [P]
+# snapshots redirect
+RewriteRule ^docs/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/docs/$2 [P]
+RewriteRule ^api/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/api/$2 [P]
+RewriteRule ^japi/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/japi/$2 [P]
 
 # Security Headers
 Header set Strict-Transport-Security "max-age=31536000"

--- a/src/main/public/.htaccess
+++ b/src/main/public/.htaccess
@@ -35,7 +35,7 @@ RewriteRule ^api/pekko-persistence-r2dbc/current/(.*)$ https://nightlies.apache.
 # pekko-projection/current gets redirected to pekko-projection/1.0.0
 RewriteRule ^docs/pekko-projection/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-projection/1.0.0/docs/$1 [P]
 RewriteRule ^api/pekko-projection/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-projection/1.0.0/api/$1 [P]
-# pekko-*/current gets redirected to pekko-*/snapshot because no releases exist yet
+# pekko-*/current gets redirected to pekko-*/snapshot if no releases exist yet
 RewriteRule ^docs/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/docs/$2 [P]
 RewriteRule ^api/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/api/$2 [P]
 RewriteRule ^japi/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/japi/$2 [P]


### PR DESCRIPTION
relates to https://github.com/apache/incubator-pekko-http/issues/493 and https://github.com/apache/incubator-pekko-http/pull/495

The redirect aims to direct to https://nightlies.apache.org/pekko/docs/pekko-http/main-snapshot/